### PR TITLE
Update to latest crate versions, remove unsafe

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ circle-ci = { repository = "mzabaluev/digest-hash-rs" }
 codecov = { repository = "mzabaluev/digest-hash-rs" }
 
 [dependencies]
-digest = "0.8"
-byteorder = "1.2"
+digest = "0.10"
+byteorder = "1.4"
 
 [dev-dependencies]
-sha2 = "0.8"
+sha2 = "0.10"

--- a/src/endian.rs
+++ b/src/endian.rs
@@ -9,42 +9,41 @@
 use byteorder;
 use byteorder::ByteOrder;
 use digest;
-use digest::generic_array::GenericArray;
 
 use std::fmt;
 use std::fmt::Debug;
 use std::marker;
-use std::mem;
 
 macro_rules! endian_methods {
     (
         $t:ty,
         $size:expr,
-        $input_method:ident,
+        $update_method:ident,
         $chain_method:ident,
         $bo_func:ident
     ) => {
-        fn $input_method(&mut self, n: $t) {
-            let mut buf: [u8; $size]
-                         = unsafe { mem::uninitialized() };
+        fn $update_method(&mut self, n: $t) {
+            let mut buf = [0; $size];
             <Self::ByteOrder>::$bo_func(&mut buf, n);
-            self.input(&buf);
+            self.update(&buf);
         }
 
         fn $chain_method(mut self, n: $t) -> Self
-        where Self: Sized {
-            self.$input_method(n);
+        where
+            Self: Sized,
+        {
+            self.$update_method(n);
             self
         }
-    }
+    };
 }
 
-/// Extends `digest::Input` to provide primitives for type-safe hashing.
+/// Extends `digest::Update` to provide primitives for type-safe hashing.
 ///
-/// `EndianInput` provides methods to process machine-independent values
+/// `EndianUpdate` provides methods to process machine-independent values
 /// of bit widths larger than 8 bit. The values are serialized with the
 /// byte order which is defined in the associated type `ByteOrder`.
-pub trait EndianInput: digest::Input {
+pub trait EndianUpdate: digest::Update {
     /// The byte order this implementation provides.
     ///
     /// This type binding determines the "endianness" of how integer
@@ -56,16 +55,16 @@ pub trait EndianInput: digest::Input {
     ///
     /// This method is agnostic to the byte order, and is only provided
     /// for completeness.
-    fn input_u8(&mut self, n: u8) {
-        self.input(&[n]);
+    fn update_u8(&mut self, n: u8) {
+        self.update(&[n]);
     }
 
     /// Feeds a signed 8-bit value into the digest function.
     ///
     /// This method is agnostic to the byte order, and is only provided
     /// for completeness.
-    fn input_i8(&mut self, n: i8) {
-        self.input(&[n as u8]);
+    fn update_i8(&mut self, n: i8) {
+        self.update(&[n as u8]);
     }
 
     /// Digest an unsigned 8-bit value in a chained manner.
@@ -76,7 +75,7 @@ pub trait EndianInput: digest::Input {
     where
         Self: Sized,
     {
-        self.chain(&[n])
+        self.chain([n])
     }
 
     /// Digest a signed 8-bit value in a chained manner.
@@ -87,7 +86,7 @@ pub trait EndianInput: digest::Input {
     where
         Self: Sized,
     {
-        self.chain(&[n as u8])
+        self.chain([n as u8])
     }
 
     for_all_mi_words!(endian_methods!);
@@ -149,40 +148,44 @@ where
     }
 }
 
-impl<D, Bo> EndianInput for Endian<D, Bo>
+impl<D, Bo> EndianUpdate for Endian<D, Bo>
 where
-    D: digest::Input,
+    D: digest::Update,
     Bo: ByteOrder,
 {
     type ByteOrder = Bo;
 }
 
-impl<D, Bo> digest::Input for Endian<D, Bo>
+impl<D, Bo> digest::Update for Endian<D, Bo>
 where
-    D: digest::Input,
+    D: digest::Update,
 {
-    fn input<B: AsRef<[u8]>>(&mut self, data: B) {
-        self.inner.input(data)
+    fn update(&mut self, data: &[u8]) {
+        self.inner.update(data)
     }
 }
 
-impl<D, Bo> digest::BlockInput for Endian<D, Bo>
+impl<D, Bo> digest::OutputSizeUser for Endian<D, Bo>
 where
-    D: digest::BlockInput,
+    D: digest::OutputSizeUser,
 {
-    type BlockSize = D::BlockSize;
+    type OutputSize = D::OutputSize;
 }
 
 impl<D, Bo> digest::FixedOutput for Endian<D, Bo>
 where
     D: digest::FixedOutput,
 {
-    type OutputSize = D::OutputSize;
+    fn finalize_into(self, out: &mut digest::Output<Self>) {
+        self.inner.finalize_into(out)
+    }
 
-    fn fixed_result(self) -> GenericArray<u8, Self::OutputSize> {
-        self.inner.fixed_result()
+    fn finalize_fixed(self) -> digest::Output<Self> {
+        self.inner.finalize_fixed()
     }
 }
+
+impl<D, Bo> digest::HashMarker for Endian<D, Bo> where D: digest::Update {}
 
 impl<D, Bo> digest::Reset for Endian<D, Bo>
 where
@@ -195,7 +198,7 @@ where
 
 impl<D, Bo> Endian<D, Bo>
 where
-    D: digest::Input,
+    D: digest::Update,
     D: Default,
     Bo: ByteOrder,
 {
@@ -221,7 +224,7 @@ where
 
 impl<D, Bo> Default for Endian<D, Bo>
 where
-    D: digest::Input,
+    D: digest::Update,
     D: Default,
     Bo: ByteOrder,
 {
@@ -232,7 +235,7 @@ where
 
 impl<D, Bo> From<D> for Endian<D, Bo>
 where
-    D: digest::Input,
+    D: digest::Update,
     Bo: ByteOrder,
 {
     fn from(digest: D) -> Self {
@@ -252,7 +255,7 @@ impl<D, Bo> Endian<D, Bo> {
 
 #[cfg(test)]
 mod tests {
-    use EndianInput;
+    use EndianUpdate;
     use {BigEndian, LittleEndian, NetworkEndian};
 
     use testmocks::conv_with;
@@ -286,11 +289,11 @@ mod tests {
     test_endian_debug!(debug_be, BigEndian);
     test_endian_debug!(debug_le, LittleEndian);
 
-    macro_rules! test_endian_input {
+    macro_rules! test_endian_update {
         (
             $test:ident,
             $Endian:ident,
-            $input_method:ident,
+            $update_method:ident,
             $chain_method:ident,
             $val:expr,
             $to_endian_bits:expr
@@ -301,7 +304,7 @@ mod tests {
                 let expected = bytes_from_endian!(val_bits);
 
                 let mut hasher = $Endian::<MockDigest>::new();
-                hasher.$input_method($val);
+                hasher.$update_method($val);
                 let output = hasher.into_inner().bytes;
                 assert_eq!(output, expected);
 
@@ -312,26 +315,26 @@ mod tests {
         };
     }
 
-    macro_rules! test_byte_input {
+    macro_rules! test_byte_update {
         (
             $be_test:ident,
             $le_test:ident,
-            $input_method:ident,
+            $update_method:ident,
             $chain_method:ident,
             $val:expr
         ) => {
-            test_endian_input!(
+            test_endian_update!(
                 $be_test,
                 BigEndian,
-                $input_method,
+                $update_method,
                 $chain_method,
                 $val,
                 |v| v
             );
-            test_endian_input!(
+            test_endian_update!(
                 $le_test,
                 LittleEndian,
-                $input_method,
+                $update_method,
                 $chain_method,
                 $val,
                 |v| v
@@ -339,18 +342,18 @@ mod tests {
         };
     }
 
-    macro_rules! test_word_input {
+    macro_rules! test_word_update {
         (
             $be_test:ident,
             $le_test:ident,
-            $input_method:ident,
+            $update_method:ident,
             $chain_method:ident,
             $val:expr
         ) => {
-            test_word_input!(
+            test_word_update!(
                 $be_test,
                 $le_test,
-                $input_method,
+                $update_method,
                 $chain_method,
                 $val,
                 |v| v
@@ -360,23 +363,23 @@ mod tests {
         (
             $be_test:ident,
             $le_test:ident,
-            $input_method:ident,
+            $update_method:ident,
             $chain_method:ident,
             $val:expr,
             $conv:expr
         ) => {
-            test_endian_input!(
+            test_endian_update!(
                 $be_test,
                 BigEndian,
-                $input_method,
+                $update_method,
                 $chain_method,
                 $val,
                 |v| conv_with(v, $conv).to_be()
             );
-            test_endian_input!(
+            test_endian_update!(
                 $le_test,
                 LittleEndian,
-                $input_method,
+                $update_method,
                 $chain_method,
                 $val,
                 |v| conv_with(v, $conv).to_le()
@@ -384,18 +387,18 @@ mod tests {
         };
     }
 
-    macro_rules! test_float_input {
+    macro_rules! test_float_update {
         (
             $be_test:ident,
             $le_test:ident,
-            $input_method:ident,
+            $update_method:ident,
             $chain_method:ident,
             $val:expr
         ) => {
-            test_word_input!(
+            test_word_update!(
                 $be_test,
                 $le_test,
-                $input_method,
+                $update_method,
                 $chain_method,
                 $val,
                 |v| v.to_bits()
@@ -403,49 +406,61 @@ mod tests {
         };
     }
 
-    test_byte_input!(u8_be_input, u8_le_input, input_u8, chain_u8, 0xA5u8);
-    test_byte_input!(i8_be_input, i8_le_input, input_i8, chain_i8, -128i8);
-    test_word_input!(u16_be_input, u16_le_input, input_u16, chain_u16, 0xA55Au16);
-    test_word_input!(i16_be_input, i16_le_input, input_i16, chain_i16, -0x7FFEi16);
-    test_word_input!(
-        u32_be_input,
-        u32_le_input,
-        input_u32,
+    test_byte_update!(u8_be_update, u8_le_update, update_u8, chain_u8, 0xA5u8);
+    test_byte_update!(i8_be_update, i8_le_update, update_i8, chain_i8, -128i8);
+    test_word_update!(
+        u16_be_update,
+        u16_le_update,
+        update_u16,
+        chain_u16,
+        0xA55Au16
+    );
+    test_word_update!(
+        i16_be_update,
+        i16_le_update,
+        update_i16,
+        chain_i16,
+        -0x7FFEi16
+    );
+    test_word_update!(
+        u32_be_update,
+        u32_le_update,
+        update_u32,
         chain_u32,
         0xA0B0_C0D0u32
     );
-    test_word_input!(
-        i32_be_input,
-        i32_le_input,
-        input_i32,
+    test_word_update!(
+        i32_be_update,
+        i32_le_update,
+        update_i32,
         chain_i32,
         -0x7F01_02FDi32
     );
-    test_word_input!(
-        u64_be_input,
-        u64_le_input,
-        input_u64,
+    test_word_update!(
+        u64_be_update,
+        u64_le_update,
+        update_u64,
         chain_u64,
         0xA0B0_C0D0_0102_0304u64
     );
-    test_word_input!(
-        i64_be_input,
-        i64_le_input,
-        input_i64,
+    test_word_update!(
+        i64_be_update,
+        i64_le_update,
+        update_i64,
         chain_i64,
         -0x7F01_0203_0405_FFFDi64
     );
-    test_float_input!(
-        f32_be_input,
-        f32_le_input,
-        input_f32,
+    test_float_update!(
+        f32_be_update,
+        f32_le_update,
+        update_f32,
         chain_f32,
         f32::consts::PI
     );
-    test_float_input!(
-        f64_be_input,
-        f64_le_input,
-        input_f64,
+    test_float_update!(
+        f64_be_update,
+        f64_le_update,
+        update_f64,
         chain_f64,
         f64::consts::PI
     );

--- a/src/endian.rs
+++ b/src/endian.rs
@@ -185,6 +185,19 @@ where
     }
 }
 
+impl<D, Bo> digest::FixedOutputReset for Endian<D, Bo>
+where
+    D: digest::FixedOutputReset,
+{
+    fn finalize_into_reset(&mut self, out: &mut digest::Output<Self>) {
+        self.inner.finalize_into_reset(out)
+    }
+
+    fn finalize_fixed_reset(&mut self) -> digest::Output<Self> {
+        self.inner.finalize_fixed_reset()
+    }
+}
+
 impl<D, Bo> digest::HashMarker for Endian<D, Bo> where D: digest::Update {}
 
 impl<D, Bo> digest::Reset for Endian<D, Bo>

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -7,7 +7,7 @@
 // except according to those terms.
 
 use digest::generic_array::{ArrayLength, GenericArray};
-use EndianInput;
+use EndianUpdate;
 
 use std::borrow::{Cow, ToOwned};
 use std::mem;
@@ -31,10 +31,10 @@ pub trait Hash {
     /// Feeds this value into the given digest function.
     ///
     /// For multi-byte data member values, the byte order is imposed by the
-    /// implementation of `EndianInput` that the digest function provides.
+    /// implementation of `EndianUpdate` that the digest function provides.
     fn hash<H>(&self, digest: &mut H)
     where
-        H: EndianInput;
+        H: EndianUpdate;
 }
 
 macro_rules! impl_hash_for {
@@ -44,17 +44,17 @@ macro_rules! impl_hash_for {
     } => {
         impl Hash for $t {
             fn hash<H>(&$self, $digest: &mut H)
-                where H: EndianInput
+                where H: EndianUpdate
             $body
         }
     }
 }
 
 macro_rules! impl_hash_for_mi_word {
-    ($t:ty, $_size:expr, $input:ident, $_chain:ident, $_bo_func:ident) => {
+    ($t:ty, $_size:expr, $update:ident, $_chain:ident, $_bo_func:ident) => {
         impl_hash_for! {
             (self: &$t, digest) {
-                digest.$input(*self);
+                digest.$update(*self);
             }
         }
     };
@@ -65,18 +65,18 @@ for_all_mi_words!(impl_hash_for_mi_word!);
 impl Hash for u8 {
     fn hash<H>(&self, digest: &mut H)
     where
-        H: EndianInput,
+        H: EndianUpdate,
     {
-        digest.input_u8(*self);
+        digest.update_u8(*self);
     }
 }
 
 impl Hash for i8 {
     fn hash<H>(&self, digest: &mut H)
     where
-        H: EndianInput,
+        H: EndianUpdate,
     {
-        digest.input_i8(*self);
+        digest.update_i8(*self);
     }
 }
 
@@ -86,9 +86,9 @@ where
 {
     fn hash<H>(&self, digest: &mut H)
     where
-        H: EndianInput,
+        H: EndianUpdate,
     {
-        digest.input(self.as_slice());
+        digest.update(self.as_slice());
     }
 }
 
@@ -98,10 +98,10 @@ where
 {
     fn hash<H>(&self, digest: &mut H)
     where
-        H: EndianInput,
+        H: EndianUpdate,
     {
         let bytes: &[u8] = unsafe { mem::transmute(self.as_slice()) };
-        digest.input(bytes);
+        digest.update(bytes);
     }
 }
 
@@ -111,7 +111,7 @@ where
 {
     fn hash<H>(&self, digest: &mut H)
     where
-        H: EndianInput,
+        H: EndianUpdate,
     {
         (*self).hash(digest);
     }
@@ -125,7 +125,7 @@ macro_rules! impl_hash_for_gen_pointer {
         {
             fn hash<H>(&self, digest: &mut H)
             where
-                H: EndianInput,
+                H: EndianUpdate,
             {
                 (**self).hash(digest);
             }
@@ -145,7 +145,7 @@ where
 {
     fn hash<H>(&self, digest: &mut H)
     where
-        H: EndianInput,
+        H: EndianUpdate,
     {
         match *self {
             Cow::Borrowed(b) => b.hash(digest),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 //! extern crate sha2;
 //!
 //! use digest_hash::{BigEndian, Hash};
-//! use digest_hash::EndianInput;
+//! use digest_hash::EndianUpdate;
 //! use sha2::{Sha256, Digest};
 //!
 //! pub struct MyHashStableStruct {
@@ -24,7 +24,7 @@
 //! }
 //!
 //! impl Hash for MyHashStableStruct {
-//!     fn hash<H: EndianInput>(&self, digest: &mut H) {
+//!     fn hash<H: EndianUpdate>(&self, digest: &mut H) {
 //!         self.foo.hash(digest);
 //!         self.bar.hash(digest);
 //!     }
@@ -35,14 +35,14 @@
 //!
 //!     let mut hasher = BigEndian::<Sha256>::new();
 //!     inst.hash(&mut hasher);
-//!     let hash = hasher.result();
+//!     let hash = hasher.finalize();
 //!
 //!     const EXPECTED: &[u8] =
 //!             &[0x71, 0x92, 0x38, 0x5c, 0x3c, 0x06, 0x05, 0xde,
 //!               0x55, 0xbb, 0x94, 0x76, 0xce, 0x1d, 0x90, 0x74,
 //!               0x81, 0x90, 0xec, 0xb3, 0x2a, 0x8e, 0xed, 0x7f,
 //!               0x52, 0x07, 0xb3, 0x0c, 0xf6, 0xa1, 0xfe, 0x89];
-//!     assert_eq!(hash.as_ref(), EXPECTED);
+//!     assert_eq!(hash.as_slice(), EXPECTED);
 //! }
 //! ```
 
@@ -56,7 +56,7 @@ mod endian;
 mod hash;
 
 pub use endian::{BigEndian, LittleEndian, NetworkEndian};
-pub use endian::{Endian, EndianInput};
+pub use endian::{Endian, EndianUpdate};
 pub use hash::Hash;
 
 #[path = "opinionated.rs"]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -10,14 +10,14 @@
 
 macro_rules! for_all_mi_words {
     ($macro:ident!) => {
-        $macro!(u16, 2, input_u16, chain_u16, write_u16);
-        $macro!(i16, 2, input_i16, chain_i16, write_i16);
-        $macro!(u32, 4, input_u32, chain_u32, write_u32);
-        $macro!(i32, 4, input_i32, chain_i32, write_i32);
-        $macro!(u64, 8, input_u64, chain_u64, write_u64);
-        $macro!(i64, 8, input_i64, chain_i64, write_i64);
-        $macro!(f32, 4, input_f32, chain_f32, write_f32);
-        $macro!(f64, 8, input_f64, chain_f64, write_f64);
+        $macro!(u16, 2, update_u16, chain_u16, write_u16);
+        $macro!(i16, 2, update_i16, chain_i16, write_i16);
+        $macro!(u32, 4, update_u32, chain_u32, write_u32);
+        $macro!(i32, 4, update_i32, chain_i32, write_i32);
+        $macro!(u64, 8, update_u64, chain_u64, write_u64);
+        $macro!(i64, 8, update_i64, chain_i64, write_i64);
+        $macro!(f32, 4, update_f32, chain_f32, write_f32);
+        $macro!(f64, 8, update_f64, chain_f64, write_f64);
     };
 }
 

--- a/src/testmocks.rs
+++ b/src/testmocks.rs
@@ -7,7 +7,7 @@
 // except according to those terms.
 
 use digest;
-use EndianInput;
+use EndianUpdate;
 use Hash;
 
 #[derive(Debug)]
@@ -21,9 +21,9 @@ impl Default for MockDigest {
     }
 }
 
-impl digest::Input for MockDigest {
-    fn input<B: AsRef<[u8]>>(&mut self, data: B) {
-        self.bytes.extend_from_slice(data.as_ref());
+impl digest::Update for MockDigest {
+    fn update(&mut self, data: &[u8]) {
+        self.bytes.extend_from_slice(data);
     }
 }
 
@@ -34,7 +34,7 @@ pub struct Hashable {
 }
 
 impl Hash for Hashable {
-    fn hash<H: EndianInput>(&self, digest: &mut H) {
+    fn hash<H: EndianUpdate>(&self, digest: &mut H) {
         self.foo.hash(digest);
         self.bar.hash(digest);
     }


### PR DESCRIPTION
Not sure if you're still interested in maintaining this, but here's a change that keeps up with `digest` changing `Input` -> `Update`.